### PR TITLE
Add Parallel Monitor API support with CRUD operations and webhook trigger

### DIFF
--- a/nodes/Parallel/Parallel.node.ts
+++ b/nodes/Parallel/Parallel.node.ts
@@ -6,7 +6,7 @@ import type {
 	INodeTypeDescription,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { operations, operationDescriptions } from './actions';
+import { operations, operationDescriptions, monitorOperationDescriptions } from './actions';
 
 export class Parallel implements INodeType {
 	description: INodeTypeDescription = {
@@ -15,7 +15,7 @@ export class Parallel implements INodeType {
 		icon: 'file:parallel.svg',
 		group: ['transform'],
 		version: 1,
-		subtitle: '={{$parameter["operation"]}}',
+		subtitle: '={{$parameter["resource"] === "monitor" ? "Monitor / " + $parameter["monitorOperation"] : $parameter["operation"]}}',
 		description: 'Highest accuracy web search tools for AI agents',
 		defaults: {
 			name: 'Parallel',
@@ -30,13 +30,50 @@ export class Parallel implements INodeType {
 		],
 		properties: [
 			{
+				displayName: 'Resource',
+				name: 'resource',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Task',
+						value: 'task',
+					},
+					{
+						name: 'Monitor',
+						value: 'monitor',
+					},
+				],
+				default: 'task',
+			},
+			{
 				displayName: 'Operation',
 				name: 'operation',
 				type: 'options',
 				noDataExpression: true,
+				displayOptions: {
+					show: {
+						resource: ['task'],
+					},
+				},
 				options: operationDescriptions,
 				default: 'webEnrichment',
 			},
+			{
+				displayName: 'Operation',
+				name: 'monitorOperation',
+				type: 'options',
+				noDataExpression: true,
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+					},
+				},
+				options: monitorOperationDescriptions,
+				default: 'createMonitor',
+			},
+
+			// ===== TASK FIELDS (existing) =====
 			// WEB ENRICHMENT FIELDS
 			{
 				displayName: 'Input Type',
@@ -45,6 +82,7 @@ export class Parallel implements INodeType {
 				required: true,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webEnrichment', 'asyncWebEnrichment'],
 					},
 				},
@@ -69,6 +107,7 @@ export class Parallel implements INodeType {
 				required: true,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webEnrichment', 'asyncWebEnrichment'],
 						inputType: ['text'],
 					},
@@ -87,6 +126,7 @@ export class Parallel implements INodeType {
 				required: true,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webEnrichment', 'asyncWebEnrichment'],
 						inputType: ['json'],
 					},
@@ -101,6 +141,7 @@ export class Parallel implements INodeType {
 				required: true,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webEnrichment'],
 					},
 				},
@@ -125,6 +166,7 @@ export class Parallel implements INodeType {
 				required: true,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['asyncWebEnrichment'],
 					},
 				},
@@ -154,6 +196,7 @@ export class Parallel implements INodeType {
 				required: false,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webEnrichment'],
 						outputSchemaType: ['text'],
 						inputType: ['text'],
@@ -170,6 +213,7 @@ export class Parallel implements INodeType {
 				required: true,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webEnrichment'],
 						outputSchemaType: ['text'],
 						inputType: ['json'],
@@ -189,6 +233,7 @@ export class Parallel implements INodeType {
 				required: true,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webEnrichment'],
 						outputSchemaType: ['json'],
 					},
@@ -207,6 +252,7 @@ export class Parallel implements INodeType {
 				required: true,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['asyncWebEnrichment'],
 						asyncOutputSchemaType: ['json'],
 					},
@@ -219,10 +265,10 @@ export class Parallel implements INodeType {
 				displayName: 'Processor',
 				name: 'processor',
 				type: 'options',
-				// When choosing pro or above, ensure your workflow timeout is sufficient. Ultra tasks may take up to 30 minutes.
 				description: 'Processor used for the task.',
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webEnrichment'],
 					},
 				},
@@ -242,7 +288,7 @@ export class Parallel implements INodeType {
 						value: 'core',
 						description: 'Cross-referenced, moderately complex outputs - 60s-5min - max 10 output fields - $25/1000 runs',
 					},
-		
+
 				],
 				default: 'base',
 			},
@@ -253,6 +299,7 @@ export class Parallel implements INodeType {
 				description: 'Processor used for the async task. Higher-end processors for longer-running tasks.',
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['asyncWebEnrichment'],
 					},
 				},
@@ -307,6 +354,7 @@ export class Parallel implements INodeType {
 				required: false,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['asyncWebEnrichment'],
 					},
 				},
@@ -321,6 +369,7 @@ export class Parallel implements INodeType {
 				placeholder: 'Add Field',
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webEnrichment', 'asyncWebEnrichment'],
 					},
 				},
@@ -382,6 +431,7 @@ export class Parallel implements INodeType {
 				required: false,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webSearch'],
 					},
 				},
@@ -395,6 +445,7 @@ export class Parallel implements INodeType {
 				type: 'options',
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webSearch'],
 					},
 				},
@@ -419,6 +470,7 @@ export class Parallel implements INodeType {
 				placeholder: 'Add Field',
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webSearch'],
 					},
 				},
@@ -485,6 +537,7 @@ export class Parallel implements INodeType {
 				required: true,
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webChat'],
 					},
 				},
@@ -497,6 +550,7 @@ export class Parallel implements INodeType {
 				type: 'options',
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webChat'],
 					},
 				},
@@ -521,6 +575,7 @@ export class Parallel implements INodeType {
 				type: 'string',
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webChat'],
 						chatResponseFormat: ['json'],
 					},
@@ -537,6 +592,7 @@ export class Parallel implements INodeType {
 				},
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webChat'],
 						chatResponseFormat: ['json'],
 					},
@@ -574,6 +630,7 @@ export class Parallel implements INodeType {
 				placeholder: 'Add Option',
 				displayOptions: {
 					show: {
+						resource: ['task'],
 						operation: ['webChat'],
 					},
 				},
@@ -592,35 +649,459 @@ export class Parallel implements INodeType {
 					},
 				],
 			},
+
+			// ===== MONITOR FIELDS =====
+
+			// Create Monitor fields
+			{
+				displayName: 'Query',
+				name: 'monitorQuery',
+				type: 'string',
+				typeOptions: {
+					rows: 3,
+				},
+				required: true,
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['createMonitor'],
+					},
+				},
+				default: '',
+				placeholder: 'Track funding announcements for AI startups',
+				description: 'What to monitor - natural language description of the events to track on the web',
+			},
+			{
+				displayName: 'Cadence',
+				name: 'monitorCadence',
+				type: 'options',
+				required: true,
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['createMonitor'],
+					},
+				},
+				options: [
+					{
+						name: 'Hourly',
+						value: 'hourly',
+						description: 'Run every hour - best for fast-moving topics',
+					},
+					{
+						name: 'Daily',
+						value: 'daily',
+						description: 'Run once per day - best for most news tracking',
+					},
+					{
+						name: 'Weekly',
+						value: 'weekly',
+						description: 'Run once per week - best for slower-changing topics',
+					},
+					{
+						name: 'Every Two Weeks',
+						value: 'every_two_weeks',
+						description: 'Run every two weeks',
+					},
+				],
+				default: 'daily',
+			},
+			{
+				displayName: 'Output Schema Type',
+				name: 'monitorOutputSchemaType',
+				type: 'options',
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['createMonitor'],
+					},
+				},
+				options: [
+					{
+						name: 'Text',
+						value: 'text',
+						description: 'Unstructured text output',
+					},
+					{
+						name: 'JSON',
+						value: 'json',
+						description: 'Structured JSON output with a schema',
+					},
+				],
+				default: 'text',
+			},
+			{
+				displayName: 'JSON Schema',
+				name: 'monitorOutputJsonSchema',
+				type: 'json',
+				typeOptions: {
+					rows: 10,
+				},
+				required: true,
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['createMonitor'],
+						monitorOutputSchemaType: ['json'],
+					},
+				},
+				default: '{\n  "type": "object",\n  "properties": {\n    "company_name": {\n      "type": "string",\n      "description": "Company name"\n    },\n    "event_summary": {\n      "type": "string",\n      "description": "Brief summary of the event"\n    },\n    "sentiment": {\n      "type": "string",\n      "description": "Sentiment: positive, negative, or neutral"\n    }\n  }\n}',
+				description: 'JSON schema defining the structure of monitor event outputs',
+			},
+			{
+				displayName: 'Webhook URL',
+				name: 'monitorWebhookUrl',
+				type: 'string',
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['createMonitor'],
+					},
+				},
+				default: '',
+				placeholder: 'https://your-n8n-instance.com/webhook/parallel-monitor-event',
+				description: 'Webhook URL to receive notifications when events are detected. Use the URL from a Parallel Monitor Event Trigger node.',
+			},
+			{
+				displayName: 'Webhook Event Types',
+				name: 'monitorWebhookEventTypes',
+				type: 'multiOptions',
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['createMonitor'],
+					},
+				},
+				options: [
+					{
+						name: 'Event Detected',
+						value: 'monitor.event.detected',
+					},
+					{
+						name: 'Execution Completed',
+						value: 'monitor.execution.completed',
+					},
+					{
+						name: 'Execution Failed',
+						value: 'monitor.execution.failed',
+					},
+				],
+				default: ['monitor.event.detected'],
+				description: 'Which webhook event types to subscribe to',
+			},
+			{
+				displayName: 'Additional Fields',
+				name: 'monitorAdditionalFields',
+				type: 'collection',
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['createMonitor'],
+					},
+				},
+				default: {},
+				options: [
+					{
+						displayName: 'Metadata',
+						name: 'metadata',
+						type: 'fixedCollection',
+						typeOptions: {
+							multipleValues: true,
+						},
+						default: {},
+						options: [
+							{
+								displayName: 'Metadata Fields',
+								name: 'metadataFields',
+								values: [
+									{
+										displayName: 'Key',
+										name: 'key',
+										type: 'string',
+										default: '',
+									},
+									{
+										displayName: 'Value',
+										name: 'value',
+										type: 'string',
+										default: '',
+									},
+								],
+							},
+						],
+						description: 'Custom metadata to store with the monitor',
+					},
+				],
+			},
+
+			// Monitor ID field (shared across get, update, delete, list events, get event group)
+			{
+				displayName: 'Monitor ID',
+				name: 'monitorId',
+				type: 'string',
+				required: true,
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['getMonitor', 'updateMonitor', 'deleteMonitor', 'listMonitorEvents', 'getMonitorEventGroup'],
+					},
+				},
+				default: '',
+				placeholder: 'monitor_b0079f70195e4258a3b982c1b6d8bd3a',
+				description: 'The ID of the monitor',
+			},
+
+			// List Monitors additional fields
+			{
+				displayName: 'Additional Fields',
+				name: 'listMonitorsAdditionalFields',
+				type: 'collection',
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['listMonitors'],
+					},
+				},
+				default: {},
+				options: [
+					{
+						displayName: 'Limit',
+						name: 'limit',
+						type: 'number',
+						typeOptions: {
+							minValue: 1,
+							maxValue: 10000,
+						},
+						default: 20,
+						description: 'Maximum number of monitors to return',
+					},
+					{
+						displayName: 'Cursor Monitor ID',
+						name: 'cursorMonitorId',
+						type: 'string',
+						default: '',
+						description: 'Monitor ID to use as cursor for pagination (returns monitors after this ID)',
+					},
+				],
+			},
+
+			// Update Monitor fields
+			{
+				displayName: 'Update Fields',
+				name: 'monitorUpdateFields',
+				type: 'collection',
+				placeholder: 'Add Field',
+				required: true,
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['updateMonitor'],
+					},
+				},
+				default: {},
+				options: [
+					{
+						displayName: 'Query',
+						name: 'query',
+						type: 'string',
+						typeOptions: {
+							rows: 3,
+						},
+						default: '',
+						description: 'Updated monitoring query',
+					},
+					{
+						displayName: 'Cadence',
+						name: 'cadence',
+						type: 'options',
+						options: [
+							{
+								name: 'Hourly',
+								value: 'hourly',
+							},
+							{
+								name: 'Daily',
+								value: 'daily',
+							},
+							{
+								name: 'Weekly',
+								value: 'weekly',
+							},
+							{
+								name: 'Every Two Weeks',
+								value: 'every_two_weeks',
+							},
+						],
+						default: 'daily',
+						description: 'Updated monitoring cadence',
+					},
+					{
+						displayName: 'Webhook URL',
+						name: 'webhookUrl',
+						type: 'string',
+						default: '',
+						description: 'Updated webhook URL for notifications',
+					},
+					{
+						displayName: 'Webhook Event Types',
+						name: 'webhookEventTypes',
+						type: 'multiOptions',
+						options: [
+							{
+								name: 'Event Detected',
+								value: 'monitor.event.detected',
+							},
+							{
+								name: 'Execution Completed',
+								value: 'monitor.execution.completed',
+							},
+							{
+								name: 'Execution Failed',
+								value: 'monitor.execution.failed',
+							},
+						],
+						default: ['monitor.event.detected'],
+						description: 'Updated webhook event types',
+					},
+					{
+						displayName: 'Metadata',
+						name: 'metadata',
+						type: 'fixedCollection',
+						typeOptions: {
+							multipleValues: true,
+						},
+						default: {},
+						options: [
+							{
+								displayName: 'Metadata Fields',
+								name: 'metadataFields',
+								values: [
+									{
+										displayName: 'Key',
+										name: 'key',
+										type: 'string',
+										default: '',
+									},
+									{
+										displayName: 'Value',
+										name: 'value',
+										type: 'string',
+										default: '',
+									},
+								],
+							},
+						],
+						description: 'Updated metadata',
+					},
+				],
+			},
+
+			// List Monitor Events additional fields
+			{
+				displayName: 'Additional Fields',
+				name: 'monitorEventsAdditionalFields',
+				type: 'collection',
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['listMonitorEvents'],
+					},
+				},
+				default: {},
+				options: [
+					{
+						displayName: 'Lookback Period',
+						name: 'lookbackPeriod',
+						type: 'string',
+						default: '',
+						placeholder: '7d',
+						description: 'How far back to look for events (e.g., 1h, 7d, 2w). Defaults to 10d.',
+					},
+				],
+			},
+
+			// Get Event Group fields
+			{
+				displayName: 'Event Group ID',
+				name: 'eventGroupId',
+				type: 'string',
+				required: true,
+				displayOptions: {
+					show: {
+						resource: ['monitor'],
+						monitorOperation: ['getMonitorEventGroup'],
+					},
+				},
+				default: '',
+				placeholder: 'mevtgrp_b0079f70195e4258eab1e7284340f1a9ec3a8033ed236a24',
+				description: 'The ID of the event group to retrieve',
+			},
 		],
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0, 'task') as string;
 
 		for (let i = 0; i < items.length; i++) {
 			try {
 				let result: IDataObject;
 
-				switch (operation) {
-					case 'webEnrichment':
-						result = await operations.webEnrichment.execute(this, i);
-						break;
-					case 'asyncWebEnrichment':
-						result = await operations.asyncWebEnrichment.execute(this, i);
-						break;
-					case 'webSearch':
-						result = await operations.webSearch.execute(this, i);
-						break;
-					case 'webChat':
-						result = await operations.webChat.execute(this, i);
-						break;
-					default:
-						throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`, {
-							itemIndex: i,
-						});
+				if (resource === 'monitor') {
+					const monitorOperation = this.getNodeParameter('monitorOperation', i) as string;
+
+					switch (monitorOperation) {
+						case 'createMonitor':
+							result = await operations.createMonitor.execute(this, i);
+							break;
+						case 'getMonitor':
+							result = await operations.getMonitor.execute(this, i);
+							break;
+						case 'listMonitors':
+							result = await operations.listMonitors.execute(this, i);
+							break;
+						case 'updateMonitor':
+							result = await operations.updateMonitor.execute(this, i);
+							break;
+						case 'deleteMonitor':
+							result = await operations.deleteMonitor.execute(this, i);
+							break;
+						case 'listMonitorEvents':
+							result = await operations.listMonitorEvents.execute(this, i);
+							break;
+						case 'getMonitorEventGroup':
+							result = await operations.getMonitorEventGroup.execute(this, i);
+							break;
+						default:
+							throw new NodeOperationError(this.getNode(), `Unknown monitor operation: ${monitorOperation}`, {
+								itemIndex: i,
+							});
+					}
+				} else {
+					const operation = this.getNodeParameter('operation', i) as string;
+
+					switch (operation) {
+						case 'webEnrichment':
+							result = await operations.webEnrichment.execute(this, i);
+							break;
+						case 'asyncWebEnrichment':
+							result = await operations.asyncWebEnrichment.execute(this, i);
+							break;
+						case 'webSearch':
+							result = await operations.webSearch.execute(this, i);
+							break;
+						case 'webChat':
+							result = await operations.webChat.execute(this, i);
+							break;
+						default:
+							throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`, {
+								itemIndex: i,
+							});
+					}
 				}
 
 				returnData.push(result);

--- a/nodes/Parallel/actions/createMonitor.operation.ts
+++ b/nodes/Parallel/actions/createMonitor.operation.ts
@@ -1,0 +1,57 @@
+import type {
+	IExecuteFunctions,
+	IDataObject,
+	INodePropertyOptions,
+} from 'n8n-workflow';
+import { parallelApiRequest } from '../transport/ParallelApi';
+import { buildMetadata } from '../utils';
+
+export const description: INodePropertyOptions = {
+	name: 'Create Monitor',
+	value: 'createMonitor',
+	description: 'Create a new web monitor that continuously tracks the web for changes on a schedule.',
+	action: 'Create a monitor',
+};
+
+export async function execute(
+	executeFunctions: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const query = executeFunctions.getNodeParameter('monitorQuery', itemIndex) as string;
+	const cadence = executeFunctions.getNodeParameter('monitorCadence', itemIndex) as string;
+
+	const body: IDataObject = {
+		query,
+		cadence,
+	};
+
+	// Webhook URL
+	const webhookUrl = executeFunctions.getNodeParameter('monitorWebhookUrl', itemIndex, '') as string;
+	if (webhookUrl) {
+		const eventTypes = executeFunctions.getNodeParameter('monitorWebhookEventTypes', itemIndex, []) as string[];
+		body.webhook = {
+			url: webhookUrl,
+			event_types: eventTypes.length > 0 ? eventTypes : ['monitor.event.detected'],
+		};
+	}
+
+	// Output schema
+	const outputSchemaType = executeFunctions.getNodeParameter('monitorOutputSchemaType', itemIndex, 'text') as string;
+	if (outputSchemaType === 'json') {
+		const jsonSchemaStr = executeFunctions.getNodeParameter('monitorOutputJsonSchema', itemIndex) as string;
+		const jsonSchema = typeof jsonSchemaStr === 'string' ? JSON.parse(jsonSchemaStr) : jsonSchemaStr;
+		body.output_schema = {
+			type: 'json',
+			json_schema: jsonSchema,
+		};
+	}
+
+	// Metadata
+	const additionalFields = executeFunctions.getNodeParameter('monitorAdditionalFields', itemIndex, {}) as IDataObject;
+	const metadata = buildMetadata(additionalFields);
+	if (metadata) {
+		body.metadata = metadata;
+	}
+
+	return await parallelApiRequest(executeFunctions, 'POST', '/v1alpha/monitors', body);
+}

--- a/nodes/Parallel/actions/createMonitor.operation.ts
+++ b/nodes/Parallel/actions/createMonitor.operation.ts
@@ -3,6 +3,7 @@ import type {
 	IDataObject,
 	INodePropertyOptions,
 } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 import { parallelApiRequest } from '../transport/ParallelApi';
 import { buildMetadata } from '../utils';
 
@@ -39,7 +40,12 @@ export async function execute(
 	const outputSchemaType = executeFunctions.getNodeParameter('monitorOutputSchemaType', itemIndex, 'text') as string;
 	if (outputSchemaType === 'json') {
 		const jsonSchemaStr = executeFunctions.getNodeParameter('monitorOutputJsonSchema', itemIndex) as string;
-		const jsonSchema = typeof jsonSchemaStr === 'string' ? JSON.parse(jsonSchemaStr) : jsonSchemaStr;
+		let jsonSchema: IDataObject;
+		try {
+			jsonSchema = typeof jsonSchemaStr === 'string' ? JSON.parse(jsonSchemaStr) : jsonSchemaStr;
+		} catch (e) {
+			throw new NodeOperationError(executeFunctions.getNode(), 'Invalid JSON schema for monitor output. Please provide valid JSON.', { itemIndex });
+		}
 		body.output_schema = {
 			type: 'json',
 			json_schema: jsonSchema,

--- a/nodes/Parallel/actions/deleteMonitor.operation.ts
+++ b/nodes/Parallel/actions/deleteMonitor.operation.ts
@@ -1,0 +1,21 @@
+import type {
+	IExecuteFunctions,
+	IDataObject,
+	INodePropertyOptions,
+} from 'n8n-workflow';
+import { parallelApiRequest } from '../transport/ParallelApi';
+
+export const description: INodePropertyOptions = {
+	name: 'Delete Monitor',
+	value: 'deleteMonitor',
+	description: 'Delete a monitor and stop all future executions.',
+	action: 'Delete a monitor',
+};
+
+export async function execute(
+	executeFunctions: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const monitorId = executeFunctions.getNodeParameter('monitorId', itemIndex) as string;
+	return await parallelApiRequest(executeFunctions, 'DELETE', `/v1alpha/monitors/${monitorId}`);
+}

--- a/nodes/Parallel/actions/getMonitor.operation.ts
+++ b/nodes/Parallel/actions/getMonitor.operation.ts
@@ -1,0 +1,21 @@
+import type {
+	IExecuteFunctions,
+	IDataObject,
+	INodePropertyOptions,
+} from 'n8n-workflow';
+import { parallelApiRequest } from '../transport/ParallelApi';
+
+export const description: INodePropertyOptions = {
+	name: 'Get Monitor',
+	value: 'getMonitor',
+	description: 'Retrieve details of a specific monitor by ID.',
+	action: 'Get a monitor',
+};
+
+export async function execute(
+	executeFunctions: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const monitorId = executeFunctions.getNodeParameter('monitorId', itemIndex) as string;
+	return await parallelApiRequest(executeFunctions, 'GET', `/v1alpha/monitors/${monitorId}`);
+}

--- a/nodes/Parallel/actions/getMonitorEventGroup.operation.ts
+++ b/nodes/Parallel/actions/getMonitorEventGroup.operation.ts
@@ -1,0 +1,27 @@
+import type {
+	IExecuteFunctions,
+	IDataObject,
+	INodePropertyOptions,
+} from 'n8n-workflow';
+import { parallelApiRequest } from '../transport/ParallelApi';
+
+export const description: INodePropertyOptions = {
+	name: 'Get Event Group',
+	value: 'getMonitorEventGroup',
+	description: 'Retrieve full details of a specific event group from a monitor.',
+	action: 'Get event group',
+};
+
+export async function execute(
+	executeFunctions: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const monitorId = executeFunctions.getNodeParameter('monitorId', itemIndex) as string;
+	const eventGroupId = executeFunctions.getNodeParameter('eventGroupId', itemIndex) as string;
+
+	return await parallelApiRequest(
+		executeFunctions,
+		'GET',
+		`/v1alpha/monitors/${monitorId}/event_groups/${eventGroupId}`,
+	);
+}

--- a/nodes/Parallel/actions/index.ts
+++ b/nodes/Parallel/actions/index.ts
@@ -2,12 +2,26 @@ import * as webEnrichment from './webEnrichment.operation';
 import * as asyncWebEnrichment from './asyncWebEnrichment.operation';
 import * as webSearch from './webSearch.operation';
 import * as webChat from './webChat.operation';
+import * as createMonitor from './createMonitor.operation';
+import * as getMonitor from './getMonitor.operation';
+import * as listMonitors from './listMonitors.operation';
+import * as updateMonitor from './updateMonitor.operation';
+import * as deleteMonitor from './deleteMonitor.operation';
+import * as listMonitorEvents from './listMonitorEvents.operation';
+import * as getMonitorEventGroup from './getMonitorEventGroup.operation';
 
 export const operations = {
 	webEnrichment,
 	asyncWebEnrichment,
 	webSearch,
 	webChat,
+	createMonitor,
+	getMonitor,
+	listMonitors,
+	updateMonitor,
+	deleteMonitor,
+	listMonitorEvents,
+	getMonitorEventGroup,
 };
 
 // Export operation descriptions for the node property options
@@ -16,4 +30,14 @@ export const operationDescriptions = [
 	asyncWebEnrichment.description,
 	webSearch.description,
 	webChat.description,
+];
+
+export const monitorOperationDescriptions = [
+	createMonitor.description,
+	getMonitor.description,
+	listMonitors.description,
+	updateMonitor.description,
+	deleteMonitor.description,
+	listMonitorEvents.description,
+	getMonitorEventGroup.description,
 ];

--- a/nodes/Parallel/actions/listMonitorEvents.operation.ts
+++ b/nodes/Parallel/actions/listMonitorEvents.operation.ts
@@ -1,0 +1,29 @@
+import type {
+	IExecuteFunctions,
+	IDataObject,
+	INodePropertyOptions,
+} from 'n8n-workflow';
+import { parallelApiRequest } from '../transport/ParallelApi';
+
+export const description: INodePropertyOptions = {
+	name: 'List Monitor Events',
+	value: 'listMonitorEvents',
+	description: 'List events detected by a monitor within a lookback period.',
+	action: 'List monitor events',
+};
+
+export async function execute(
+	executeFunctions: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const monitorId = executeFunctions.getNodeParameter('monitorId', itemIndex) as string;
+	const additionalFields = executeFunctions.getNodeParameter('monitorEventsAdditionalFields', itemIndex, {}) as IDataObject;
+
+	let endpoint = `/v1alpha/monitors/${monitorId}/events`;
+
+	if (additionalFields.lookbackPeriod) {
+		endpoint += `?lookback_period=${additionalFields.lookbackPeriod}`;
+	}
+
+	return await parallelApiRequest(executeFunctions, 'GET', endpoint);
+}

--- a/nodes/Parallel/actions/listMonitors.operation.ts
+++ b/nodes/Parallel/actions/listMonitors.operation.ts
@@ -1,0 +1,42 @@
+import type {
+	IExecuteFunctions,
+	IDataObject,
+	INodePropertyOptions,
+} from 'n8n-workflow';
+import { parallelApiRequest } from '../transport/ParallelApi';
+
+export const description: INodePropertyOptions = {
+	name: 'List Monitors',
+	value: 'listMonitors',
+	description: 'List all monitors with optional pagination.',
+	action: 'List monitors',
+};
+
+export async function execute(
+	executeFunctions: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const additionalFields = executeFunctions.getNodeParameter('listMonitorsAdditionalFields', itemIndex, {}) as IDataObject;
+
+	let endpoint = '/v1alpha/monitors';
+	const queryParams: string[] = [];
+
+	if (additionalFields.limit) {
+		queryParams.push(`limit=${additionalFields.limit}`);
+	}
+	if (additionalFields.cursorMonitorId) {
+		queryParams.push(`monitor_id=${additionalFields.cursorMonitorId}`);
+	}
+
+	if (queryParams.length > 0) {
+		endpoint += `?${queryParams.join('&')}`;
+	}
+
+	const result = await parallelApiRequest(executeFunctions, 'GET', endpoint);
+
+	// The API returns an array directly; wrap it for consistent n8n output
+	if (Array.isArray(result)) {
+		return { monitors: result } as IDataObject;
+	}
+	return result;
+}

--- a/nodes/Parallel/actions/updateMonitor.operation.ts
+++ b/nodes/Parallel/actions/updateMonitor.operation.ts
@@ -1,0 +1,45 @@
+import type {
+	IExecuteFunctions,
+	IDataObject,
+	INodePropertyOptions,
+} from 'n8n-workflow';
+import { parallelApiRequest } from '../transport/ParallelApi';
+import { buildMetadata } from '../utils';
+
+export const description: INodePropertyOptions = {
+	name: 'Update Monitor',
+	value: 'updateMonitor',
+	description: 'Update an existing monitor\'s query, cadence, webhook, or metadata.',
+	action: 'Update a monitor',
+};
+
+export async function execute(
+	executeFunctions: IExecuteFunctions,
+	itemIndex: number,
+): Promise<IDataObject> {
+	const monitorId = executeFunctions.getNodeParameter('monitorId', itemIndex) as string;
+	const updateFields = executeFunctions.getNodeParameter('monitorUpdateFields', itemIndex, {}) as IDataObject;
+
+	const body: IDataObject = {};
+
+	if (updateFields.query) {
+		body.query = updateFields.query;
+	}
+	if (updateFields.cadence) {
+		body.cadence = updateFields.cadence;
+	}
+	if (updateFields.webhookUrl) {
+		const eventTypes = (updateFields.webhookEventTypes as string[]) || ['monitor.event.detected'];
+		body.webhook = {
+			url: updateFields.webhookUrl,
+			event_types: eventTypes,
+		};
+	}
+
+	const metadata = buildMetadata(updateFields);
+	if (metadata) {
+		body.metadata = metadata;
+	}
+
+	return await parallelApiRequest(executeFunctions, 'POST', `/v1alpha/monitors/${monitorId}`, body);
+}

--- a/nodes/ParallelMonitorTrigger.node.ts
+++ b/nodes/ParallelMonitorTrigger.node.ts
@@ -1,0 +1,256 @@
+import type {
+	IDataObject,
+	INodeType,
+	INodeTypeDescription,
+	IWebhookFunctions,
+	IWebhookResponseData,
+	JsonObject,
+} from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { parallelApiRequestForWebhook } from './Parallel/transport/ParallelApi';
+
+export class ParallelMonitorTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Parallel Monitor Event Trigger',
+		name: 'parallelMonitorTrigger',
+		icon: 'file:parallel.svg',
+		group: ['trigger'],
+		version: 1,
+		description: 'Triggers when a Parallel Monitor detects events, completes an execution, or encounters an error',
+		defaults: {
+			name: 'Parallel Monitor Event',
+		},
+		inputs: [],
+		outputs: ['main'],
+		credentials: [
+			{
+				name: 'parallelApi',
+				required: true,
+			},
+		],
+		webhooks: [
+			{
+				name: 'default',
+				httpMethod: 'POST',
+				responseMode: 'onReceived',
+				path: 'parallel-monitor-event',
+			},
+		],
+		properties: [
+			{
+				displayName: 'Webhook URL',
+				name: 'webhookUrl',
+				type: 'notice',
+				default: '',
+				description: 'Use the webhook URL that n8n provides for this trigger node when creating or updating your Parallel monitor.',
+			},
+			{
+				displayName: 'Event Types',
+				name: 'eventTypeFilter',
+				type: 'multiOptions',
+				options: [
+					{
+						name: 'Event Detected',
+						value: 'monitor.event.detected',
+						description: 'Fired when material events are detected by the monitor',
+					},
+					{
+						name: 'Execution Completed',
+						value: 'monitor.execution.completed',
+						description: 'Fired when a monitor run completes successfully with no new events',
+					},
+					{
+						name: 'Execution Failed',
+						value: 'monitor.execution.failed',
+						description: 'Fired when a monitor run fails with an error',
+					},
+				],
+				default: ['monitor.event.detected'],
+				description: 'Which event types to trigger on',
+			},
+			{
+				displayName: 'Fetch Full Event Group',
+				name: 'fetchEventGroup',
+				type: 'boolean',
+				default: true,
+				description: 'Whether to fetch the full event group details when an event is detected. Only applies to monitor.event.detected events.',
+			},
+			{
+				displayName: 'Validate Webhook Signatures',
+				name: 'validateSignatures',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to validate webhook signatures using your webhook secret. Note: Due to JSON serialization differences, signature validation may fail even with correct secrets. Disable for testing.',
+			},
+			{
+				displayName: 'Include Webhook Data',
+				name: 'includeWebhookData',
+				type: 'boolean',
+				default: false,
+				description: 'Adds the raw webhook payload to the output as webhook_data. Useful for debugging.',
+			},
+		],
+	};
+
+	private static verifyWebhookSignature(
+		secret: string,
+		webhookId: string,
+		webhookTimestamp: string,
+		body: string,
+		signatureHeader: string,
+	): boolean {
+		const payload = `${webhookId}.${webhookTimestamp}.${body}`;
+		const expectedSignature = createHmac('sha256', secret)
+			.update(payload)
+			.digest('base64');
+
+		const signatures = signatureHeader.split(' ');
+		for (const sig of signatures) {
+			if (sig.startsWith('v1,')) {
+				const providedSignature = sig.substring(3);
+				const expectedBuffer = Buffer.from(expectedSignature);
+				const providedBuffer = Buffer.from(providedSignature);
+
+				if (expectedBuffer.length === providedBuffer.length &&
+					timingSafeEqual(expectedBuffer, providedBuffer)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private async validateWebhook(this: IWebhookFunctions): Promise<void> {
+		const validateSignatures = this.getNodeParameter('validateSignatures') as boolean;
+
+		if (!validateSignatures) {
+			return;
+		}
+
+		try {
+			const credentials = await this.getCredentials('parallelApi');
+			const webhookSecret = credentials.webhookSecret as string;
+
+			if (!webhookSecret) {
+				throw new NodeApiError(this.getNode(), {}, {
+					message: 'Webhook signature validation is enabled but no webhook secret is configured. Please add your webhook secret to the Parallel API credentials.',
+					description: 'Get your webhook secret from https://platform.parallel.ai/settings',
+				});
+			}
+
+			const headers = this.getHeaderData();
+			const webhookId = headers['webhook-id'] as string;
+			const webhookTimestamp = headers['webhook-timestamp'] as string;
+			const webhookSignature = headers['webhook-signature'] as string;
+
+			if (!webhookId || !webhookTimestamp || !webhookSignature) {
+				throw new NodeApiError(this.getNode(), {}, {
+					message: 'Missing required webhook headers (webhook-id, webhook-timestamp, or webhook-signature)',
+					description: 'This webhook request does not appear to be from Parallel or is malformed.',
+				});
+			}
+
+			let body: string;
+			try {
+				body = (this as any).getRequest?.()?.rawBody || JSON.stringify(this.getBodyData());
+			} catch {
+				body = JSON.stringify(this.getBodyData(), null, 0);
+			}
+
+			const isValidSignature = ParallelMonitorTrigger.verifyWebhookSignature(
+				webhookSecret,
+				webhookId,
+				webhookTimestamp,
+				body,
+				webhookSignature,
+			);
+
+			if (!isValidSignature) {
+				throw new NodeApiError(this.getNode(), {}, {
+					message: 'Invalid webhook signature',
+					description: 'The webhook signature could not be verified. Consider disabling signature validation for testing.',
+				});
+			}
+		} catch (error) {
+			if (error instanceof NodeApiError) {
+				throw error;
+			}
+			throw new NodeApiError(this.getNode(), error as JsonObject, {
+				message: `Webhook signature validation failed: ${(error as Error).message}`,
+			});
+		}
+	}
+
+	private async processWebhookPayload(this: IWebhookFunctions, bodyData: IDataObject): Promise<IWebhookResponseData> {
+		const eventTypeFilter = this.getNodeParameter('eventTypeFilter') as string[];
+		const includeWebhookData = this.getNodeParameter('includeWebhookData') as boolean;
+		const fetchEventGroup = this.getNodeParameter('fetchEventGroup') as boolean;
+
+		const eventType = bodyData.type as string;
+
+		// Filter by event type
+		if (!eventType || !eventTypeFilter.includes(eventType)) {
+			return { noWebhookResponse: true };
+		}
+
+		const data = bodyData.data as IDataObject;
+		if (!data) {
+			return { noWebhookResponse: true };
+		}
+
+		const outputData: IDataObject = {
+			event_type: eventType,
+			monitor_id: data.monitor_id as string,
+			timestamp: bodyData.timestamp as string,
+			metadata: data.metadata || {},
+		};
+
+		// For event.detected, optionally fetch full event group
+		if (eventType === 'monitor.event.detected' && fetchEventGroup) {
+			const eventData = data.event as IDataObject;
+			if (eventData?.event_group_id) {
+				try {
+					const eventGroup = await parallelApiRequestForWebhook(
+						this,
+						'GET',
+						`/v1alpha/monitors/${data.monitor_id}/event_groups/${eventData.event_group_id}`,
+					);
+					outputData.event_group_id = eventData.event_group_id;
+					outputData.event_group = eventGroup;
+				} catch (error) {
+					// Include the error but don't fail the webhook
+					outputData.event_group_id = eventData.event_group_id;
+					outputData.event_group_error = (error as Error).message;
+				}
+			}
+		} else if (eventType === 'monitor.event.detected') {
+			const eventData = data.event as IDataObject;
+			if (eventData) {
+				outputData.event_group_id = eventData.event_group_id;
+			}
+		} else {
+			// For completion/failure events, include the event data directly
+			outputData.event = data.event || {};
+		}
+
+		if (includeWebhookData) {
+			outputData.webhook_data = bodyData;
+		}
+
+		return {
+			workflowData: [
+				this.helpers.returnJsonArray([outputData]),
+			],
+		};
+	}
+
+	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		const bodyData = this.getBodyData() as IDataObject;
+
+		await ParallelMonitorTrigger.prototype.validateWebhook.call(this);
+
+		return await ParallelMonitorTrigger.prototype.processWebhookPayload.call(this, bodyData);
+	}
+}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
 		],
 		"nodes": [
 			"dist/nodes/Parallel/Parallel.node.js",
-			"dist/nodes/ParallelTrigger.node.js"
+			"dist/nodes/ParallelTrigger.node.js",
+			"dist/nodes/ParallelMonitorTrigger.node.js"
 		]
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

Adds full support for the **Parallel Monitor API** (`v1alpha`), enabling n8n users to create and manage web monitors that continuously track the web for changes on a configurable schedule.

### What's new

- **Resource-based routing** on the main Parallel node — new `Resource` dropdown (`Task` / `Monitor`) that cleanly separates existing task operations from the new monitor operations. Fully backward-compatible: defaults to `Task`, so existing workflows are unaffected.

- **7 Monitor operations** added to the Parallel node:

  | Operation | Endpoint | Description |
  |-----------|----------|-------------|
  | Create Monitor | `POST /v1alpha/monitors` | Create a scheduled web monitor with query, cadence, webhook config, JSON output schema, and metadata |
  | Get Monitor | `GET /v1alpha/monitors/{id}` | Retrieve monitor details by ID |
  | List Monitors | `GET /v1alpha/monitors` | List all monitors with pagination support |
  | Update Monitor | `POST /v1alpha/monitors/{id}` | Update query, cadence, webhook, or metadata |
  | Delete Monitor | `DELETE /v1alpha/monitors/{id}` | Stop and delete a monitor |
  | List Events | `GET /v1alpha/monitors/{id}/events` | List detected events with configurable lookback period |
  | Get Event Group | `GET /v1alpha/monitors/{id}/event_groups/{gid}` | Retrieve full event group details |

- **New `Parallel Monitor Event Trigger` node** — webhook-based trigger that fires when monitors detect events, complete executions, or encounter errors. Features:
  - Configurable event type filtering (`monitor.event.detected`, `monitor.execution.completed`, `monitor.execution.failed`)
  - Optional automatic fetching of full event group details on event detection
  - HMAC-SHA256 webhook signature validation (same pattern as existing Task trigger)
  - Raw webhook data passthrough for debugging

### Typical workflow patterns

1. **Event-driven:** Create Monitor node (one-time setup) → Monitor Event Trigger node (listens for webhooks) → process detected events
2. **Polling-based:** Schedule Trigger → List Events node (with lookback period) → process new events

### Files changed

- `nodes/Parallel/Parallel.node.ts` — Added resource routing and all monitor UI fields
- `nodes/Parallel/actions/` — 7 new operation files (`createMonitor`, `getMonitor`, `listMonitors`, `updateMonitor`, `deleteMonitor`, `listMonitorEvents`, `getMonitorEventGroup`)
- `nodes/Parallel/actions/index.ts` — Exports for new operations
- `nodes/ParallelMonitorTrigger.node.ts` — New webhook trigger node
- `package.json` — Registered new trigger node

### Notes

- The Monitor API is currently in **public alpha** (`v1alpha`) — endpoints may evolve
- No new transport functions were needed; existing `parallelApiRequest` supports the new endpoints
- All endpoints tested against the live Parallel API and confirmed working

## Test plan

- [x] `npm run build` compiles without errors
- [x] Existing Task operations (Web Enrichment, Async Web Enrichment, Web Search, Web Chat) still work with no changes
- [x] Create Monitor with text output and verify `monitor_id` returned
- [x] Create Monitor with JSON output schema and verify schema is preserved
- [x] List Monitors returns array of monitors
- [x] Get Monitor returns correct monitor details
- [x] Update Monitor changes cadence/query/webhook successfully
- [x] List Events returns events for an active monitor
- [x] Get Event Group returns full event details
- [x] Delete Monitor sets status to canceled
- [ ] Monitor Event Trigger node receives and filters webhook payloads correctly (requires live n8n instance)
- [ ] Webhook signature validation works when enabled (requires live n8n instance)
